### PR TITLE
Changed MODKEY to OTHER_MOD when initiating period operator

### DIFF
--- a/config.h
+++ b/config.h
@@ -101,7 +101,7 @@ static const Key keys[] = {
 	{ MODKEY, NORMAL, XK_m, resize_master, {.i = 5} },
 	{ MODKEY | ShiftMask, NORMAL, XK_m, resize_master, {.i = -5} },
 	{ MODKEY, NORMAL, XK_b, toggle_bar, {NULL} },
-	{ MODKEY, NORMAL, XK_period, replay, {NULL} },
+	{ OTHER_MOD, NORMAL, XK_period, replay, {NULL} },
 
 	{ MODKEY | ShiftMask, FLOATING, XK_k, resize_float_height, {.i = -10} },
 	{ MODKEY | ShiftMask, FLOATING, XK_j, resize_float_height, {.i = 10} },


### PR DESCRIPTION
This commit changes the config.h to specify that period
operator is called using the OTHER_MOD, as this key is used
globally for all the operators and period is also termed as
an operator in the vim lingo.
