### PR TITLE
Resize master only when resizing is visible (i.e. in Stack layouts).

### DIFF
--- a/howm.c
+++ b/howm.c
@@ -2117,6 +2117,7 @@ static void delete_win(xcb_window_t win)
  */
 static void resize_master(const Arg *arg)
 {
+	/* Resize master only when resizing is visible (i.e. in Stack layouts). */
 	if (wss[cw].layout != HSTACK && wss[cw].layout != VSTACK)
 		return;
 


### PR DESCRIPTION
Resizing master only makes sense(according to me) if the resizing is visible. In layouts like GRID and ZOOM where its not, the user has no clue that the master's size is being changed in the background. 
