### PR TITLE
Do not free reply on error.

### DIFF
--- a/howm.c
+++ b/howm.c
@@ -2753,8 +2753,8 @@ static void apply_rules(Client *c)
 				break;
 			}
 		}
+		xcb_icccm_get_wm_class_reply_wipe(&wc);
 	}
-	xcb_icccm_get_wm_class_reply_wipe(&wc);
 }
 
 /**


### PR DESCRIPTION
When running some X windows, in my case xev, `xcb_icccm_get_wm_class_reply` will fail, but howm will still call a clean up function to clean it up which causes howm to crash. For some reason, the function call also doesn't reseat an `xcb_generic_err_t` in my tests so I can't pinpoint what causes this either.

Checking the icccm source though, it seems simply not cleaning up the structure should suffice to fix the problem as the error occurs due to the wipe function calling free [here](http://cgit.freedesktop.org/xcb/util-wm/tree/icccm/icccm.c#n377). If the `get_wm_class_reply` function fails, free is automatically called anyway so there is no harm in leaving the reply struct dirty.
