### PR TITLE
Feature/xsession list entry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,8 @@ DLINK_FLAGS =
 DESTDIR = /
 # Install path (bin/ is appended automatically)
 INSTALL_PREFIX = usr/local
+# Xsession entries path
+XSESSION_PREFIX = usr/share
 #### END PROJECT SETTINGS ####
 
 # Generally should not need to edit below this line
@@ -113,6 +115,8 @@ dirs:
 install:
 	@echo "Installing to $(DESTDIR)$(INSTALL_PREFIX)/bin"
 	@install -m 0755 $(BIN_PATH)/$(BIN_NAME) $(DESTDIR)$(INSTALL_PREFIX)/bin
+	@install -d -m 0755 $(DESTDIR)$(XSESSION_PREFIX)/xsessions
+	@install -m 0644 howm.xsession.desktop $(DESTDIR)$(XSESSION_PREFIX)/xsessions/howm.desktop
 
 .PHONY: check
 check:

--- a/howm.xsession.desktop
+++ b/howm.xsession.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Name=howm
+Comment=A lightweight, X11 tiling window manager that behaves like vim
+Exec=howm
+TryExec=howm
+Type=XSession
+X-LightDM-DesktopName=howm


### PR DESCRIPTION
This adds and will install an X session desktop entry file in order to
    list howm as an available X session to display managers that read
    available sessions from /usr/share/xsessions
